### PR TITLE
Adapt Upstream Object's Costomizable Fields

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,4 +14,4 @@ blis_jll = "6136c539-28a5-5bf0-87cc-b183200dce32"
 
 [compat]
 julia = "1.4"
-blis_jll = "0.8.0"
+blis_jll = "< 0.8.2"

--- a/src/backend_object/object.jl
+++ b/src/backend_object/object.jl
@@ -29,6 +29,13 @@ mutable struct BliObjBase
     m_panel::BliDim
     n_panel::BliDim
 
+    # Additional fields from upstream flame/blis#583.
+    # Currently these customizable fields have no Julia interface.
+    pack_fn::Ptr{Nothing}
+    pack_params::Ptr{Nothing}
+    ker_fn::Ptr{Nothing}
+    ker_params::Ptr{Nothing}
+
     # Empty inner-constructor only,
     #  resembling a plain C struct.
     BliObjBase() = begin


### PR DESCRIPTION
flame/blis#583 introdues 4 additional user customizable function fields.
As BLIS.jl was using an outdated duplication of blis.h:obj_t, upgrading blis_jll v0.8.1 would cause the whole BLAS interface to break down.
Resolves #9 
Resolves #8