### PR TITLE
Upgrade to BLIS v0.9

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,8 +12,7 @@ jobs:
         arch:
           - x64
         version:
-          - '1.4'
-          - '1.5'
+          - '1.7'
           - 'nightly'
         os:
           - macOS-latest

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.5'
+          version: '1.7'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/Project.toml
+++ b/Project.toml
@@ -13,5 +13,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 blis_jll = "6136c539-28a5-5bf0-87cc-b183200dce32"
 
 [compat]
-julia = "1.4"
-blis_jll = "0.7.0 - 0.8.1"
+julia = "1.7"
+blis_jll = "0.9.0"


### PR DESCRIPTION
Definitions used in this Julia wrapper should not have changed since JuliaBinaryWrappers/blis_jll.jl@a8bc99b .

Resolves #12 .